### PR TITLE
Watch directory for new images

### DIFF
--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -1834,7 +1834,7 @@ def __parse_img(
         return parsed_img_data
 
 
-def get_atlas_output(input_file_paths, args):
+def parse_into_json(input_file_paths, args):
     """
     The version of output gathering used by AtlasAcademy. Made to resemble capy's output.
     """
@@ -2067,5 +2067,5 @@ if __name__ == '__main__':
         inputs = args.filenames
 
     inputs = sort_files(inputs, args.ordering)
-    parsed_output = get_atlas_output(inputs, args)
+    parsed_output = parse_into_json(inputs, args)
     output_json(parsed_output, args.out_folder)

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -1974,6 +1974,8 @@ def watch_parse_output_into_json(args):
 
         time.sleep(int(args.polling_frequency))
 
+    input_queue.close()
+    input_queue.join_thread()
     pool.close()
     pool.join()
 

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -1938,7 +1938,7 @@ def __signal_handling(*_):
         sys.exit(1)
     watcher_running = False
     print(
-        "Notice: app may take up to polling frequency time and however long it takes to finish the queue before exting."
+        "Notice: app may take up to polling frequency time and however long it takes to finish the queue before exiting."
     )
 
 

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -1913,7 +1913,7 @@ def __parse_into_json_process(input_queue, args):
     (svm, svm_chest, svm_card) = load_svms()
 
     global watcher_running
-    while watcher_running:
+    while watcher_running or not input_queue.empty():
         input_file_path = input_queue.get()
         # Detection of missing screenshots/pages (e.g. scrolled down image with no previous
         # image to go along with it), is dissabled with `prev_pages=-1`. This is because

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -1851,13 +1851,7 @@ def move_file_to_out_dir(src_file_path, out_dir):
     return src_file_path
 
 
-def parse_into_json(input_file_paths, args):
-    """
-    The version of output gathering used by AtlasAcademy. Made to resemble capy's output.
-    """
-    debug = args.debug
-
-    calc_dist_local()
+def check_svms_trained():
     if train_item.exists() is False:
         print("[エラー]item.xml が存在しません")
         print("python makeitem.py を実行してください")
@@ -1870,6 +1864,16 @@ def parse_into_json(input_file_paths, args):
         print("[エラー]card.xml が存在しません")
         print("python makecard.py を実行してください")
         sys.exit(1)
+
+
+def parse_into_json(input_file_paths, args):
+    """
+    The version of output gathering used by AtlasAcademy. Made to resemble capy's output.
+    """
+    debug = args.debug
+
+    calc_dist_local()
+    check_svms_trained()
 
     (svm, svm_chest, svm_card) = load_svms()
 

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -1737,14 +1737,14 @@ def get_output(filenames, args):
     return fileoutput, all_list
 
 
-def __load_svms():
+def load_svms():
     svm = cv2.ml.SVM_load(str(train_item))
     svm_chest = cv2.ml.SVM_load(str(train_chest))
     svm_card = cv2.ml.SVM_load(str(train_card))
     return (svm, svm_chest, svm_card)
 
 
-def __parse_img(
+def parse_img(
         svm,
         svm_chest,
         svm_card,
@@ -1854,7 +1854,7 @@ def parse_into_json(input_file_paths, args):
         print("python makecard.py を実行してください")
         sys.exit(1)
 
-    (svm, svm_chest, svm_card) = __load_svms()
+    (svm, svm_chest, svm_card) = load_svms()
 
     prev_pages = 0
     prev_pagenum = 0
@@ -1865,7 +1865,7 @@ def parse_into_json(input_file_paths, args):
     all_parsed_output = []
 
     for file_path in input_file_paths:
-        all_parsed_output.append(__parse_img(
+        all_parsed_output.append(parse_img(
             svm,
             svm_chest,
             svm_card,

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -1603,6 +1603,8 @@ def get_output(filenames, args):
                     td = datetime.timedelta(days=1)
                 else:
                     td = dt - prev_datetime
+                if sc.pages - sc.pagenum == 0:
+                    sc.itemlist = sc.itemlist[14-(sc.lines+2) % 3*7:]
                 if prev_itemlist == sc.itemlist:
                     if (sc.total_qp != 999999999
                         and sc.total_qp == prev_total_qp) \
@@ -1631,8 +1633,6 @@ def get_output(filenames, args):
                     fileoutput.append({'filename': 'missing'})
                     all_list.append([])
 
-                if sc.pages - sc.pagenum == 0:
-                    sc.itemlist = sc.itemlist[14-(sc.lines+2) % 3*7:]
                 all_list.append(sc.itemlist)
 
                 prev_pages = sc.pages

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -225,8 +225,7 @@ class ScreenShot:
             cv2.rectangle(img_copy, topleft, bottomright, (0, 0, 255), 3)
             cv2.imwrite("./scroll_bar_selected.jpg", img_copy)
 
-        gray_image = self.img_gray[topleft[1]
-            : bottomright[1], topleft[0]: bottomright[0]]
+        gray_image = self.img_gray[topleft[1]: bottomright[1], topleft[0]: bottomright[0]]
         _, binary = cv2.threshold(gray_image, 225, 255, cv2.THRESH_BINARY)
         if debug:
             cv2.imwrite("scroll_bar_binary.png", binary)
@@ -1834,6 +1833,24 @@ def parse_img(
         return parsed_img_data
 
 
+def move_file_to_out_dir(src_file_path, out_dir):
+    if out_dir is not None:
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
+
+        src_file_path = Path(src_file_path)
+        if not src_file_path.exists():
+            print("Cannot move {}. It does not exist.".format(src_file_path))
+            exit(1)
+
+        dst_file_path = "{}/{}".format(out_dir, src_file_path.name)
+        os.rename(src_file_path, dst_file_path)
+
+        return dst_file_path
+
+    return src_file_path
+
+
 def parse_into_json(input_file_paths, args):
     """
     The version of output gathering used by AtlasAcademy. Made to resemble capy's output.
@@ -1865,6 +1882,7 @@ def parse_into_json(input_file_paths, args):
     all_parsed_output = []
 
     for file_path in input_file_paths:
+        file_path = move_file_to_out_dir(file_path, args.out_folder)
         all_parsed_output.append(parse_img(
             svm,
             svm_chest,
@@ -2033,7 +2051,7 @@ if __name__ == '__main__':
     parser.add_argument('filenames', help='入力ファイル', nargs='*')    # 必須の引数を追加
     parser.add_argument('-f', '--folder', help='フォルダで指定')
     parser.add_argument('-o', '--out_folder',
-                        help='directory to write parsed data to. If none is provided, output will be written to stdout')
+                        help='directory to write parsed data to. If specified, provided images will also be moved to here. Else, output will simply be written to stdout')
     parser.add_argument('-t', '--timeout', type=int, default=TIMEOUT,
                         help='QPカンスト時の重複チェック間隔(秒): デフォルト' + str(TIMEOUT) + '秒')
     parser.add_argument('--ordering', help='ファイルの処理順序 (未指定の場合 notspecified)',

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -2050,18 +2050,21 @@ def output_json(parsed_output, out_folder):
 
 if __name__ == '__main__':
     # オプションの解析
-    parser = argparse.ArgumentParser(description='FGOスクショからアイテムをCSV出力する')
+    parser = argparse.ArgumentParser(
+        description='Parse item drops from an F/GO screenshot.')
     # 3. parser.add_argumentで受け取る引数を追加していく
-    parser.add_argument('filenames', help='入力ファイル', nargs='*')    # 必須の引数を追加
-    parser.add_argument('-f', '--folder', help='フォルダで指定')
+    parser.add_argument(
+        'filenames', help='image file to parse', nargs='*')    # 必須の引数を追加
+    parser.add_argument(
+        '-f', '--folder', help='folder containing images to parse')
     parser.add_argument('-o', '--out_folder',
-                        help='directory to write parsed data to. If specified, provided images will also be moved to here. Else, output will simply be written to stdout')
+                        help='folder to write parsed data to. If specified, parsed images will also be moved to here. Else, output will simply be written to stdout')
     parser.add_argument('-t', '--timeout', type=int, default=TIMEOUT,
-                        help='QPカンスト時の重複チェック間隔(秒): デフォルト' + str(TIMEOUT) + '秒')
-    parser.add_argument('--ordering', help='ファイルの処理順序 (未指定の場合 notspecified)',
-                        type=Ordering,
-                        choices=list(Ordering), default=Ordering.NOTSPECIFIED)
-    parser.add_argument('-d', '--debug', help='デバッグ情報の出力', action='store_true')
+                        help="images with the same amount of drops and QP are flagged as duplicate, if taken within this many seconds. Default= {}s".format(TIMEOUT))
+    parser.add_argument('--ordering', help='sort files before processing. Needed to make use of missing screenshot detection',
+                        type=Ordering, choices=list(Ordering), default=Ordering.NOTSPECIFIED)
+    parser.add_argument(
+        '-d', '--debug', help='output debug information', action='store_true')
     parser.add_argument('--version', action='version',
                         version=PROGNAME + " " + VERSION)
     parser.add_argument('-l', '--loglevel',

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -258,13 +258,13 @@ class ScreenShot:
         """
         capy-drop-parser から流用
         """
-        pt = pageinfo.detect_qp_region(self.img_rgb_orig)
-        logger.debug('pt: %s', pt)
+        pt = pageinfo.detect_qp_region(self.img_rgb)
+        logger.debug('pt from pageinfo: %s', pt)
         if pt is None:
-            return QP_UNKNOWN
+            pt = ((288, 948), (838, 1024))
 
         qp_total_text = self.extract_text_from_image(
-            self.img_rgb_orig[pt[0][1]: pt[1][1], pt[0][0]: pt[1][0]]
+            self.img_rgb[pt[0][1]: pt[1][1], pt[0][0]: pt[1][0]]
         )
 
         qp_total = self.get_qp_from_text(qp_total_text)

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -1765,7 +1765,7 @@ def parse_img(
 
     if debug:
         print(file_path)
-    parsed_img_data["image_path"] = str(file_path)
+    parsed_img_data["image_path"] = str(os.path.abspath(file_path))
 
     if not Path(file_path).exists():
         # TODO: is this needed?

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -2185,7 +2185,17 @@ if __name__ == '__main__':
             ndir.mkdir(parents=True)
 
     # Attributes are only present if the watch subcommand has been invoked.
-    if not (hasattr(args, "num_processes") and hasattr(args, "polling_frequency")):
+    if hasattr(args, "num_processes") and hasattr(args, "polling_frequency"):
+        if args.folder is None or not Path(args.folder).exists():
+            print(
+                "The watch subcommands requires a valid input directory. Provide one with --folder.")
+            exit(1)
+        watch_parse_output_into_json(args)
+    else:
+        if args.filenames is None and args.folder is None:
+            print(
+                "No input files specified. Use --filenames or --folder to do so.")
+            exit(1)
         # gather input image files
         if args.folder:
             inputs = [x for x in Path(args.folder).iterdir()]
@@ -2195,9 +2205,3 @@ if __name__ == '__main__':
         inputs = sort_files(inputs, args.ordering)
         parsed_output = parse_into_json(inputs, args)
         output_json(parsed_output, args.out_folder)
-    else:
-        if args.folder is None or not Path(args.folder).exists():
-            print(
-                "The watch subcommands requires a valid input directory. Provide one with --folder.")
-            exit(1)
-        watch_parse_output_into_json(args)

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -1834,7 +1834,8 @@ def parse_img(
         return parsed_img_data
 
     except Exception as e:
-        logger.error(e, exc_info=True)
+        logger.error("Error during parsing of {}\n{}\n".format(
+            file_path, e), exc_info=True)
         parsed_img_data["status"] = "Invalid file"
         return parsed_img_data
 

--- a/fgosccnt.py
+++ b/fgosccnt.py
@@ -66,6 +66,8 @@ ID_SYURENJYO = 94006800
 ID_EVNET = 94000000
 TIMEOUT = 15
 QP_UNKNOWN = -1
+DEFAULT_POLL_FREQ = 60
+DEFAULT_AMT_PROCESSES = 1
 
 
 with open(drop_file, encoding='UTF-8') as f:
@@ -2060,7 +2062,7 @@ if __name__ == '__main__':
     parser.add_argument('-o', '--out_folder',
                         help='folder to write parsed data to. If specified, parsed images will also be moved to here. Else, output will simply be written to stdout')
     parser.add_argument('-t', '--timeout', type=int, default=TIMEOUT,
-                        help="images with the same amount of drops and QP are flagged as duplicate, if taken within this many seconds. Default= {}s".format(TIMEOUT))
+                        help="images with the same amount of drops and QP are flagged as duplicate, if taken within this many seconds. Default: {}s".format(TIMEOUT))
     parser.add_argument('--ordering', help='sort files before processing. Needed to make use of missing screenshot detection',
                         type=Ordering, choices=list(Ordering), default=Ordering.NOTSPECIFIED)
     parser.add_argument(
@@ -2069,6 +2071,29 @@ if __name__ == '__main__':
                         version=PROGNAME + " " + VERSION)
     parser.add_argument('-l', '--loglevel',
                         choices=('debug', 'info'), default='info')
+    subparsers = parser.add_subparsers(
+        title='subcommands', description='{subcommand} --help: show help message for the subcommand',)
+
+    watcher_parser = subparsers.add_parser(
+        'watch', help='continuously watch the folder specified by [-f FOLDER]')
+    watcher_parser.add_argument(
+        "-j",
+        "--num_processes",
+        required=False,
+        default=DEFAULT_AMT_PROCESSES,
+        type=int,
+        help="number of processes to allocate in the process pool. Default: {}".format(
+            DEFAULT_AMT_PROCESSES),
+    )
+    watcher_parser.add_argument(
+        "-p",
+        "--polling_frequency",
+        required=False,
+        default=DEFAULT_POLL_FREQ,
+        type=int,
+        help="how often to check for new images (in seconds). Default: {}s".format(
+            DEFAULT_POLL_FREQ),
+    )
 
     args = parser.parse_args()    # 引数を解析
     logging.basicConfig(


### PR DESCRIPTION
Add functionality to continuously watch a directory for new images. Moves images to the output dir and places processed json data next to it.

Had to change the argument parser such that individual input images (*not* input directory) have to be specified with `-i`. Originally the input images were unnamed and unlimited arguments, which acted up in combination with the new `watch` sub-command.

Also translated the CLI parameter descriptions to English.

Sometimes the processes don't stop when sending the interrupt signal, even after waiting for the queue to clear. Still looking into this. 